### PR TITLE
Revert removal of `ruby-2.6`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
         allow-failures: [false]
         include:
           - ruby: head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 * Remove `codeclimate` config, since we don't use it any more.
 * Check `dependabot` at 8:00 Moscow time daily
-* Remove `ruby-2.6` from CI, since `parallel_tests` do not support it
 
 ## 0.4.0 (2021-01-21)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,4 +100,4 @@ DEPENDENCIES
   yard (>= 0.9.20)
 
 BUNDLED WITH
-   2.3.10
+   2.3.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,4 +100,4 @@ DEPENDENCIES
   yard (>= 0.9.20)
 
 BUNDLED WITH
-   2.3.5
+   2.3.10


### PR DESCRIPTION
This reverts commit 47c655f2dd9dd33f9cfdbbf67f9fd0a220977723.

Support is resolved via https://github.com/ONLYOFFICE-QA/onlyoffice_pdf_parser/pull/269