### PR TITLE
Fix warning about license name on `gem build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Drop support `ruby-2.6`, `ruby-2.7` since it's EOL'ed
 * Allow `rmagick-6.x` usage as dependency
 
+### Fixes
+
+* Fix warning about license name on `gem build`
+
 ## 0.5.0 (2022-10-10)
 
 ### New Features

--- a/onlyoffice_pdf_parser.gemspec
+++ b/onlyoffice_pdf_parser.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency('image_size', '>= 2', '< 4')
   s.add_dependency('pdf-reader', '~> 2')
   s.add_dependency('rmagick', '>= 4', '< 7')
-  s.license = 'AGPL-3.0'
+  s.license = 'AGPL-3.0-or-later'
 end


### PR DESCRIPTION
WARNING:  License identifier 'AGPL-3.0' is deprecated. Use an identifier from
https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
or set it to nil if you don't want to specify a license.
Did you mean 'AFL-3.0', 'APL-1.0'?
