### PR TITLE
Fix warning about homepage on `gem build` stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 * Fix warning about license name on `gem build`
+* Fix warning about homepage on `gem build` stage
 
 ## 0.5.0 (2022-10-10)
 

--- a/onlyoffice_pdf_parser.gemspec
+++ b/onlyoffice_pdf_parser.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => "#{s.homepage}/issues",
     'changelog_uri' => "#{s.homepage}/blob/master/CHANGELOG.md",
     'documentation_uri' => "https://www.rubydoc.info/gems/#{s.name}",
-    'homepage_uri' => s.homepage,
     'source_code_uri' => s.homepage,
     'rubygems_mfa_required' => 'true'
   }


### PR DESCRIPTION
```
$ gem build onlyoffice_pdf_parser
WARNING:  You have specified the uri:
  https://github.com/ONLYOFFICE-QA/onlyoffice_pdf_parser
for all of the following keys:
  homepage_uri
  source_code_uri
Only the first one will be shown on rubygems.org
```